### PR TITLE
fix(engine, web, docs): add lifespan for fastapi

### DIFF
--- a/docs/_includes/register-vs-set-webhook.md
+++ b/docs/_includes/register-vs-set-webhook.md
@@ -2,7 +2,8 @@
 
 | Step | Call | Purpose |
 | --- | --- | --- |
-| Local route | `engine.register(app)` | Registers `POST` in your web framework and wires engine startup/shutdown. |
+| Local route | `engine.register(app)` | Registers `POST` in your web framework. With aiohttp, also wires engine startup/shutdown via callback lists. |
+| Lifecycle (FastAPI) | `engine.lifespan(app)` | Async context manager — runs engine startup on enter, shutdown on exit. Required for FastAPI; not needed for aiohttp. |
 | Telegram delivery | `await engine.set_webhook()` | Tells Telegram the public HTTPS URL for future updates. |
 
 Run `set_webhook()` from framework startup **after** the endpoint is reachable. For `TokenEngine`, call `add_bot(token)` per bot instead.

--- a/docs/engines/token-engine.md
+++ b/docs/engines/token-engine.md
@@ -123,7 +123,7 @@ async def set_webhooks(app):
     await engine.add_bot("654321:UVWXYZ")
 ```
 
-`engine.register(app)` wires local framework callbacks. `engine.add_bot()` resolves the bot and calls Telegram.
+`engine.register(app)` registers the local route (with aiohttp, also wires lifecycle callbacks). For FastAPI, wrap startup in `engine.lifespan(app)` — see [FastAPI adapter](../web/fastapi.md). `engine.add_bot()` resolves the bot and calls Telegram.
 
 ### shutdown_timeout
 

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -141,8 +141,9 @@ blocks:
 
           @asynccontextmanager
           async def lifespan(app: FastAPI):
-              await engine.set_webhook()
-              yield
+              async with engine.lifespan(app):
+                  await engine.set_webhook()
+                  yield
 
 
           app = FastAPI(lifespan=lifespan)

--- a/docs/web/custom.md
+++ b/docs/web/custom.md
@@ -4,7 +4,7 @@ Create a custom adapter when your web framework is not FastAPI or aiohttp. The a
 
 `FastAPIAdapter` and `AiohttpAdapter` are shipped reference implementations — useful to read, not mandatory templates. Study their source when you need working lifecycle wiring or multipart reply handling:
 
-* `aiogram_webhook.web.fastapi` — router lifespan, Starlette payload bridge
+* `aiogram_webhook.web.fastapi` — `engine.lifespan(app)` context manager pattern, Starlette payload bridge
 * `aiogram_webhook.web.aiohttp` — `web.Application` routes and startup/shutdown hooks
 
 See also [Extending overview](../custom-integrations.md) for how adapters fit next to engines and security.

--- a/docs/web/fastapi.md
+++ b/docs/web/fastapi.md
@@ -1,6 +1,6 @@
 # FastAPI Adapter
 
-`FastAPIAdapter` is the web-framework component for FastAPI applications. It binds a webhook engine to a `FastAPI` app, registers a `POST` route, and composes engine lifecycle callbacks with the application's lifespan.
+`FastAPIAdapter` is the web-framework component for FastAPI applications. It binds a webhook engine to a `FastAPI` app and registers a `POST` route. Engine lifecycle is managed separately via `engine.lifespan(app)` inside the application's lifespan function.
 
 Use it when the rest of your application already lives in FastAPI or when you want FastAPI's dependency, middleware, and deployment ecosystem around aiogram.
 
@@ -28,12 +28,13 @@ engine = SingleBotEngine(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await engine.set_webhook()
-    yield
+    engine.register(app)
+    async with engine.lifespan(app):
+        await engine.set_webhook()
+        yield
 
 
 app = FastAPI(lifespan=lifespan)
-engine.register(app)
 ```
 
 ## Request mapping
@@ -49,8 +50,8 @@ engine.register(app)
 
 {% note tip %}
 
-FastAPI keeps your application lifespan.
-The adapter adds engine startup/shutdown through the included router, so you can keep application setup and webhook registration in the app lifespan.
+FastAPI does not wire engine lifecycle through `register()`.
+Use `engine.lifespan(app)` as an async context manager inside the application lifespan to run engine startup and shutdown in the correct order.
 
 {% endnote %}
 
@@ -66,4 +67,4 @@ The adapter streams it as Telegram-compatible multipart payload when needed, inc
 | Engine | Calls `register(app)` with a FastAPI app. |
 | Route | Provides the path that becomes a FastAPI `POST` route. |
 | Security | Runs inside the engine after the adapter normalizes the request. |
-| Lifecycle | Uses router lifespan, so application lifespan can still call `set_webhook()`. |
+| Lifecycle | Use `engine.lifespan(app)` inside your app lifespan; call `set_webhook()` after entering it. |

--- a/src/aiogram_webhook/engines/base.py
+++ b/src/aiogram_webhook/engines/base.py
@@ -1,5 +1,7 @@
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any, Generic, TypeVar
 
 from aiogram import Bot
@@ -110,6 +112,14 @@ class BaseWebhookEngine(ABC, Generic[AppT, RawRequestT, FrameworkResponseT]):
     async def on_shutdown(self, app: AppT, *args: Any, **kwargs: Any) -> None:
         self._is_shutting_down = True
         await self._on_shutdown(app, *args, **kwargs)
+
+    @asynccontextmanager
+    async def lifespan(self, app: AppT) -> AsyncGenerator[None, Any]:
+        try:
+            await self.on_startup(app=app)
+            yield
+        finally:
+            await self.on_shutdown(app=app)
 
     @abstractmethod
     async def _on_startup(self, app: AppT, *args: Any, **kwargs: Any) -> None:

--- a/src/aiogram_webhook/web/fastapi.py
+++ b/src/aiogram_webhook/web/fastapi.py
@@ -1,12 +1,10 @@
-from collections.abc import AsyncIterator, Mapping
-from contextlib import asynccontextmanager
+from collections.abc import Mapping
 from typing import Any
 
 from aiohttp import Payload
-from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from starlette.types import Lifespan
 
 from aiogram_webhook.web._starlette import AiohttpPayloadResponse
 from aiogram_webhook.web.base import (
@@ -60,33 +58,19 @@ class FastAPIAdapter(WebAdapter[FastAPI, Request, Response]):
     def bind_request(self, request: Request) -> WebRequest[Request]:
         return FastAPIWebRequest(request)
 
-    @staticmethod
-    def _build_lifespan(on_startup: LifecycleCallback, on_shutdown: LifecycleCallback) -> Lifespan[FastAPI]:
-        @asynccontextmanager
-        async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-            await on_startup(app)
-            try:
-                yield
-            finally:
-                await on_shutdown(app)
-
-        return lifespan
-
     def register(
         self,
         app: FastAPI,
         path: str,
         handler: WebHandler[Request, Response],
         *,
-        on_startup: LifecycleCallback,
-        on_shutdown: LifecycleCallback,
+        on_startup: LifecycleCallback,  # noqa: ARG002
+        on_shutdown: LifecycleCallback,  # noqa: ARG002
     ) -> None:
         async def endpoint(request: Request) -> Response:
             return await handler(self.bind_request(request))
 
-        router = APIRouter(lifespan=self._build_lifespan(on_startup, on_shutdown))
-        router.add_api_route(path=path, endpoint=endpoint, methods=["POST"])
-        app.include_router(router)
+        app.add_api_route(path=path, endpoint=endpoint, methods=["POST"])
 
     def json_response(
         self, status_code: int, data: dict[str, str] | None = None, headers: Mapping[str, str] | None = None

--- a/tests/test_fastapi_web.py
+++ b/tests/test_fastapi_web.py
@@ -1,13 +1,20 @@
 from contextlib import asynccontextmanager
+from typing import Any
 
+import pytest
 from aiogram.methods import SendDocument, SendMessage
 from aiogram.types import BufferedInputFile
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from aiogram_webhook.engines.base import BaseWebhookEngine
+from aiogram_webhook.engines.target import Target
+from aiogram_webhook.route import Route
+from aiogram_webhook.tasks import TaskTracker
 from aiogram_webhook.utils._payload import build_webhook_payload
 from aiogram_webhook.web.fastapi import FastAPIAdapter
 from tests.fixtures.multipart_payload import assert_attached_file, assert_multipart_fields
+from tests.fixtures.webhook_engine import DummyDispatcher
 
 
 def test_fastapi_adapter_passes_bound_request_to_registered_post_handler():
@@ -55,79 +62,58 @@ def test_fastapi_adapter_passes_bound_request_to_registered_post_handler():
     assert seen["json"] == {"update_id": 1}
 
 
-def test_fastapi_adapter_registers_lifecycle_callbacks_with_app_lifespan():
-    adapter = FastAPIAdapter()
+def test_fastapi_adapter_registers_lifecycle_callbacks_with_app_lifespan(bot):
     events = []
+    adapter = FastAPIAdapter()
+
+    class SpyEngine(BaseWebhookEngine[Any, Any, Any]):
+        _task_tracker = TaskTracker()
+
+        async def _on_startup(self, app, *args, **kwargs) -> None:
+            events.append(("engine_startup", app))
+
+        async def _on_shutdown(self, app, *args, **kwargs) -> None:
+            events.append(("engine_shutdown", app))
+
+        async def _resolve_target(self, request, route_params) -> Target:
+            return Target(bot_id=bot.id, bot_token=bot.token)
+
+        async def _resolve_bot(self, target) -> Any:
+            return bot
+
+        def _get_task_tracker(self, bot) -> TaskTracker:
+            return self._task_tracker
+
+    with pytest.warns(UserWarning, match="Security is not configured"):
+        engine = SpyEngine(
+            DummyDispatcher(),
+            web=adapter,
+            route=Route(base_url="https://example.com", path="/webhook"),
+            handle_in_background=False,
+        )
 
     @asynccontextmanager
     async def app_lifespan(app: FastAPI):
         events.append(("app_startup", app))
-        try:
+        engine.register(app)
+        async with engine.lifespan(app):
             yield
-        finally:
-            events.append(("app_shutdown", app))
+        events.append(("app_shutdown", app))
 
     app = FastAPI(lifespan=app_lifespan)
 
-    async def handler(_request):
-        return adapter.json_response(status_code=200, data={"ok": "yes"})
-
-    async def on_startup(app: FastAPI):
-        events.append(("adapter_startup", app))
-
-    async def on_shutdown(app: FastAPI):
-        events.append(("adapter_shutdown", app))
-
-    adapter.register(app, "/webhook", handler, on_startup=on_startup, on_shutdown=on_shutdown)
-
     with TestClient(app) as client:
-        assert events == [("app_startup", app), ("adapter_startup", app)]
+        assert events == [("app_startup", app), ("engine_startup", app)]
         response = client.post("/webhook", json={"update_id": 1})
 
     assert response.status_code == 200
-    assert response.json() == {"ok": "yes"}
+    assert response.json() == {}
     assert events == [
         ("app_startup", app),
-        ("adapter_startup", app),
-        ("adapter_shutdown", app),
+        ("engine_startup", app),
+        ("engine_shutdown", app),
         ("app_shutdown", app),
     ]
-
-
-def test_fastapi_adapter_composes_lifecycle_callbacks_for_multiple_registrations():
-    adapter = FastAPIAdapter()
-    app = FastAPI()
-    events = []
-
-    async def first_handler(_request):
-        return adapter.json_response(status_code=200, data={"handler": "first"})
-
-    async def second_handler(_request):
-        return adapter.json_response(status_code=200, data={"handler": "second"})
-
-    async def first_startup(_app):
-        events.append("first_startup")
-
-    async def first_shutdown(_app):
-        events.append("first_shutdown")
-
-    async def second_startup(_app):
-        events.append("second_startup")
-
-    async def second_shutdown(_app):
-        events.append("second_shutdown")
-
-    adapter.register(app, "/first", first_handler, on_startup=first_startup, on_shutdown=first_shutdown)
-    adapter.register(app, "/second", second_handler, on_startup=second_startup, on_shutdown=second_shutdown)
-
-    with TestClient(app) as client:
-        assert events == ["first_startup", "second_startup"]
-        first_response = client.post("/first", json={"update_id": 1})
-        second_response = client.post("/second", json={"update_id": 2})
-
-    assert first_response.json() == {"handler": "first"}
-    assert second_response.json() == {"handler": "second"}
-    assert events == ["first_startup", "second_startup", "second_shutdown", "first_shutdown"]
 
 
 def test_fastapi_adapter_streams_webhook_method_payload_as_multipart(bot):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `engine.lifespan()` async context manager for managing webhook engine lifecycle.

* **Documentation**
  * Clarified webhook engine configuration patterns and differences between aiohttp and FastAPI.
  * Updated FastAPI integration examples to demonstrate the recommended `engine.lifespan()` context manager pattern.
  * Enhanced guidance on engine lifecycle management and framework-specific registration approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->