### PR TITLE
feat(web): add auto lifespan for fastapi, update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![PyPI version](docs/_assets/brand/banner.png)
+![Aiogram Webhook](docs/_assets/brand/banner.png)
 
 # aiogram-webhook
 [![PyPI version](https://img.shields.io/pypi/v/aiogram-webhook?color=blue)](https://pypi.org/project/aiogram-webhook)
@@ -6,11 +6,10 @@
 [![Tests Status](https://github.com/m-xim/aiogram-webhook/actions/workflows/tests.yml/badge.svg)](https://github.com/m-xim/aiogram-webhook/actions)
 [![License](https://img.shields.io/github/license/m-xim/aiogram-webhook.svg)](/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/m-xim/aiogram-webhook)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 
-`aiogram-webhook` is a modular Python library for webhook integration in aiogram.
-It supports single-bot and token-based multi-bot setups, with route building, optional request checks, and adapters for FastAPI and aiohttp.
+Handles the webhook layer for aiogram bots. Registers the endpoint, calls Telegram `setWebhook`, verifies incoming requests, and manages engine lifecycle. Works with FastAPI and aiohttp.
 
 ## Install
 
@@ -20,35 +19,9 @@ pip install "aiogram-webhook[fastapi]"
 pip install "aiogram-webhook[aiohttp]"
 ```
 
-## Quick Start
-
-```python
-from aiogram import Bot, Dispatcher
-from fastapi import FastAPI
-
-from aiogram_webhook import FastAPIAdapter, SingleBotEngine
-from aiogram_webhook.route import Route
-
-dispatcher = Dispatcher()
-bot = Bot("BOT_TOKEN")
-
-engine = SingleBotEngine(
-    dispatcher,
-    bot,
-    web=FastAPIAdapter(),
-    route=Route(base_url="https://example.com", path="/webhook"),
-)
-
-app = FastAPI()
-engine.register(app)
-```
-
-Call `await engine.set_webhook()` during your application startup to register the public webhook URL in Telegram.
-For production, pass `security=Security(...)` to verify Telegram requests.
-
 ## Documentation
 
-The full documentation is in [`docs`](https://aiogram-webhook.m-xim.ru). It covers installation, FastAPI and aiohttp setup, routing, security, lifecycle behavior, and the public API.
+The full documentation is at [aiogram-webhook.m-xim.ru](https://aiogram-webhook.m-xim.ru). It covers installation, setup, routing, security, lifecycle behavior, and the public API.
 
 ## Contributing
 

--- a/docs/_includes/register-vs-set-webhook.md
+++ b/docs/_includes/register-vs-set-webhook.md
@@ -2,8 +2,7 @@
 
 | Step | Call | Purpose |
 | --- | --- | --- |
-| Local route | `engine.register(app)` | Registers `POST` in your web framework. With aiohttp, also wires engine startup/shutdown via callback lists. |
-| Lifecycle (FastAPI) | `engine.lifespan(app)` | Async context manager — runs engine startup on enter, shutdown on exit. Required for FastAPI; not needed for aiohttp. |
+| Local route + lifecycle | `engine.register(app)` | Registers `POST` route and wires engine startup/shutdown in your web framework. |
 | Telegram delivery | `await engine.set_webhook()` | Tells Telegram the public HTTPS URL for future updates. |
 
 Run `set_webhook()` from framework startup **after** the endpoint is reachable. For `TokenEngine`, call `add_bot(token)` per bot instead.

--- a/docs/engines/token-engine.md
+++ b/docs/engines/token-engine.md
@@ -123,7 +123,7 @@ async def set_webhooks(app):
     await engine.add_bot("654321:UVWXYZ")
 ```
 
-`engine.register(app)` registers the local route (with aiohttp, also wires lifecycle callbacks). For FastAPI, wrap startup in `engine.lifespan(app)` — see [FastAPI adapter](../web/fastapi.md). `engine.add_bot()` resolves the bot and calls Telegram.
+`engine.register(app)` registers the local route and wires lifecycle callbacks. `engine.add_bot()` resolves the bot and calls Telegram.
 
 ### shutdown_timeout
 

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,11 +1,11 @@
 meta:
   title: 'aiogram-webhook'
-  description: 'Webhook integration for aiogram with FastAPI and aiohttp.'
+  description: 'Webhook layer for aiogram — route registration, setWebhook, request verification, and lifecycle management for FastAPI and aiohttp.'
 
 blocks:
   - type: 'header-block'
     title: 'Aiogram Webhook'
-    description: 'Webhook adapter for aiogram. Plug FastAPI or aiohttp into your existing bot — handlers, FSM, and filters stay untouched.'
+    description: 'Handles the webhook layer for aiogram bots. Registers the endpoint, calls Telegram setWebhook, verifies incoming requests, and manages engine lifecycle.'
     background:
       dark:
         color: '#101827'
@@ -141,9 +141,8 @@ blocks:
 
           @asynccontextmanager
           async def lifespan(app: FastAPI):
-              async with engine.lifespan(app):
-                  await engine.set_webhook()
-                  yield
+              await engine.set_webhook()
+              yield
 
 
           app = FastAPI(lifespan=lifespan)

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -27,7 +27,7 @@ security = Security(
 engine = SingleBotEngine(dispatcher, bot, web=adapter, route=route, security=security)
 ```
 
-Pass `security` to the engine, not the adapter — verification stays independent of FastAPI, aiohttp, or a custom framework.
+Pass `security` to the engine, not the adapter — verification stays independent of the web framework.
 
 {% note info %}
 

--- a/docs/web/custom.md
+++ b/docs/web/custom.md
@@ -4,7 +4,7 @@ Create a custom adapter when your web framework is not FastAPI or aiohttp. The a
 
 `FastAPIAdapter` and `AiohttpAdapter` are shipped reference implementations — useful to read, not mandatory templates. Study their source when you need working lifecycle wiring or multipart reply handling:
 
-* `aiogram_webhook.web.fastapi` — `engine.lifespan(app)` context manager pattern, Starlette payload bridge
+* `aiogram_webhook.web.fastapi` — lifespan wiring, Starlette payload bridge
 * `aiogram_webhook.web.aiohttp` — `web.Application` routes and startup/shutdown hooks
 
 See also [Extending overview](../custom-integrations.md) for how adapters fit next to engines and security.
@@ -116,4 +116,4 @@ engine = SingleBotEngine(
 engine.register(app)
 ```
 
-Engine and `Route` configuration are identical to FastAPI or aiohttp — only `web=` changes.
+Engine and `Route` configuration are identical regardless of the adapter — only `web=` changes.

--- a/docs/web/fastapi.md
+++ b/docs/web/fastapi.md
@@ -1,14 +1,12 @@
 # FastAPI Adapter
 
-`FastAPIAdapter` is the web-framework component for FastAPI applications. It binds a webhook engine to a `FastAPI` app and registers a `POST` route. Engine lifecycle is managed separately via `engine.lifespan(app)` inside the application's lifespan function.
+`FastAPIAdapter` is the web-framework component for FastAPI applications. It binds a webhook engine to a `FastAPI` app and registers a `POST` route.
 
 Use it when the rest of your application already lives in FastAPI or when you want FastAPI's dependency, middleware, and deployment ecosystem around aiogram.
 
 Runnable example with handlers and security: see **Minimal app — FastAPI** on the home page.
 
 ```python
-from contextlib import asynccontextmanager
-
 from aiogram import Bot, Dispatcher
 from fastapi import FastAPI
 
@@ -25,16 +23,8 @@ engine = SingleBotEngine(
     route=Route(base_url="https://example.com", path="/webhook"),
 )
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    engine.register(app)
-    async with engine.lifespan(app):
-        await engine.set_webhook()
-        yield
-
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
+engine.register(app)
 ```
 
 ## Request mapping
@@ -48,13 +38,6 @@ app = FastAPI(lifespan=lifespan)
 | `path_params` | `request.path_params` |
 | `json()` | `await request.json()` |
 
-{% note tip %}
-
-FastAPI does not wire engine lifecycle through `register()`.
-Use `engine.lifespan(app)` as an async context manager inside the application lifespan to run engine startup and shutdown in the correct order.
-
-{% endnote %}
-
 ## Returning Telegram methods
 
 When `handle_in_background=False`, aiogram may return a `TelegramMethod`.
@@ -67,4 +50,4 @@ The adapter streams it as Telegram-compatible multipart payload when needed, inc
 | Engine | Calls `register(app)` with a FastAPI app. |
 | Route | Provides the path that becomes a FastAPI `POST` route. |
 | Security | Runs inside the engine after the adapter normalizes the request. |
-| Lifecycle | Use `engine.lifespan(app)` inside your app lifespan; call `set_webhook()` after entering it. |
+| Lifecycle | Managed by `engine.register(app)`. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ dev = [
 requires = ["uv_build<0.12"]
 build-backend = "uv_build"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Security is not configured:UserWarning",
+]
+
 [tool.uv]
 package = true
 

--- a/src/aiogram_webhook/web/fastapi.py
+++ b/src/aiogram_webhook/web/fastapi.py
@@ -1,8 +1,9 @@
 from collections.abc import Mapping
+from contextlib import asynccontextmanager
 from typing import Any
 
 from aiohttp import Payload
-from fastapi import FastAPI, Request, Response
+from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 
@@ -64,13 +65,23 @@ class FastAPIAdapter(WebAdapter[FastAPI, Request, Response]):
         path: str,
         handler: WebHandler[Request, Response],
         *,
-        on_startup: LifecycleCallback,  # noqa: ARG002
-        on_shutdown: LifecycleCallback,  # noqa: ARG002
+        on_startup: LifecycleCallback,
+        on_shutdown: LifecycleCallback,
     ) -> None:
         async def endpoint(request: Request) -> Response:
             return await handler(self.bind_request(request))
 
-        app.add_api_route(path=path, endpoint=endpoint, methods=["POST"])
+        @asynccontextmanager
+        async def lifespan(_router: APIRouter):
+            try:
+                await on_startup(app)
+                yield
+            finally:
+                await on_shutdown(app)
+
+        router = APIRouter(lifespan=lifespan)
+        router.add_api_route(path=path, endpoint=endpoint, methods=["POST"])
+        app.include_router(router)
 
     def json_response(
         self, status_code: int, data: dict[str, str] | None = None, headers: Mapping[str, str] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 from aiogram import Bot
 
 from aiogram_webhook.engines.target import Target
+from tests.fixtures.web_request import DummyRequest, DummyWebRequest
+from tests.fixtures.webhook_engine import CapturingAdapter, DummyDispatcher
 
 
 @pytest.fixture
@@ -25,5 +27,15 @@ def target(bot_id: int, bot_token: str) -> Target:
 
 
 @pytest.fixture
-def update_payload() -> dict[str, int]:
-    return {"update_id": 1}
+def adapter() -> CapturingAdapter:
+    return CapturingAdapter()
+
+
+@pytest.fixture
+def update_request() -> DummyWebRequest:
+    return DummyWebRequest(DummyRequest(json_data={"update_id": 1}))
+
+
+@pytest.fixture
+def dispatcher() -> DummyDispatcher:
+    return DummyDispatcher()

--- a/tests/fixtures/shutdown.py
+++ b/tests/fixtures/shutdown.py
@@ -32,9 +32,6 @@ class BlockingShutdownDispatcher(DummyDispatcher):
         self.background_session_closed.append(getattr(bot.session, "closed", None))
         await self.background_continue.wait()
 
-    async def silent_call_request(self, bot: Any, result: Any) -> None:
-        return None
-
 
 class BlockingDispatcher(DummyDispatcher):
     """Test dispatcher that blocks raw update handling until released."""

--- a/tests/fixtures/webhook_engine.py
+++ b/tests/fixtures/webhook_engine.py
@@ -1,12 +1,11 @@
 from collections.abc import Mapping
 from typing import Any
 
-from aiogram_webhook.route import Route
 from aiogram_webhook.route.params import RouteParams
 from aiogram_webhook.web.base import WebAdapter
 
 
-class DummyRoute(Route):
+class DummyRoute:
     path = "/webhook"
 
     def __init__(self, route_params: Mapping[str, str] | None = None) -> None:
@@ -54,4 +53,10 @@ class DummyDispatcher:
         return self.result
 
     async def silent_call_request(self, bot, result):
+        return None
+
+    async def emit_startup(self, **kwargs) -> None:
+        return None
+
+    async def emit_shutdown(self, **kwargs) -> None:
         return None

--- a/tests/test_base_webhook_engine.py
+++ b/tests/test_base_webhook_engine.py
@@ -30,7 +30,7 @@ class EngineProbe(BaseWebhookEngine[Any, Any, dict[str, Any]]):
         super().__init__(
             dispatcher,  # ty:ignore[invalid-argument-type]
             web=web,
-            route=DummyRoute({"bot_token": "42:TEST"}),
+            route=DummyRoute({"bot_token": "42:TEST"}),  # ty:ignore[invalid-argument-type]
             handle_in_background=handle_in_background,
         )
 
@@ -51,125 +51,113 @@ class EngineProbe(BaseWebhookEngine[Any, Any, dict[str, Any]]):
 
 
 @pytest.mark.asyncio
-async def test_foreground_engine_returns_telegram_method_as_webhook_payload(bot, target, update_payload):
-    adapter = CapturingAdapter()
+async def test_foreground_engine_returns_telegram_method_as_webhook_payload(bot, target, adapter, update_request):
     dispatcher = DummyDispatcher(result=SendMessage(chat_id=42, text="OK"))
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "payload", "status_code": 200, "headers": None}
     assert adapter.payload is not None
-    assert dispatcher.webhook_update == update_payload
+    assert dispatcher.webhook_update == update_request.raw.json_data
 
 
 @pytest.mark.asyncio
-async def test_foreground_engine_acknowledges_empty_dispatcher_result(bot, target, update_payload):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher(result=None)
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
+async def test_foreground_engine_acknowledges_empty_dispatcher_result(bot, target, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 200, "data": {}, "headers": None}
     assert adapter.payload is None
 
 
 @pytest.mark.asyncio
-async def test_foreground_engine_acknowledges_non_method_dispatcher_result(bot, target, update_payload):
-    adapter = CapturingAdapter()
+async def test_foreground_engine_acknowledges_non_method_dispatcher_result(bot, target, adapter, update_request):
     dispatcher = DummyDispatcher(result={"handled": True})
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 200, "data": {}, "headers": None}
     assert adapter.payload is None
 
 
 @pytest.mark.asyncio
-async def test_background_engine_acknowledges_without_webhook_payload(bot, target, update_payload):
-    adapter = CapturingAdapter()
+async def test_background_engine_acknowledges_without_webhook_payload(bot, target, adapter, update_request):
     dispatcher = DummyDispatcher(result=SendMessage(chat_id=42, text="OK"))
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter, handle_in_background=True)
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter, handle_in_background=True)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
     await asyncio.sleep(0)
 
     assert response == {"kind": "json", "status_code": 200, "data": {}, "headers": None}
-    assert dispatcher.webhook_update == update_payload
+    assert dispatcher.webhook_update == update_request.raw.json_data
     assert adapter.payload is None
 
 
 @pytest.mark.asyncio
-async def test_engine_stops_accepting_requests_after_shutdown_starts(bot, target, update_payload):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
-
+async def test_engine_stops_accepting_requests_after_shutdown_starts(bot, target, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
     await engine.on_shutdown(None)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 503, "data": {"detail": "Service unavailable"}, "headers": None}
     assert dispatcher.webhook_update is None
 
 
 @pytest.mark.asyncio
-async def test_engine_accepts_requests_again_after_startup(bot, target, update_payload):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
-
+async def test_engine_accepts_requests_again_after_startup(bot, target, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
     await engine.on_shutdown(None)
     await engine.on_startup(None)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 200, "data": {}, "headers": None}
-    assert dispatcher.webhook_update == update_payload
+    assert dispatcher.webhook_update == update_request.raw.json_data
 
 
 @pytest.mark.asyncio
-async def test_engine_returns_not_found_when_target_cannot_be_resolved(bot, update_payload):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=None, web=adapter)
+async def test_engine_returns_not_found_when_target_cannot_be_resolved(bot, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot, target=None, web=adapter)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 404, "data": {"detail": "Not found"}, "headers": None}
     assert dispatcher.webhook_update is None
 
 
 @pytest.mark.asyncio
-async def test_engine_returns_not_found_when_bot_cannot_be_resolved(target, update_payload):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot=None, target=target, web=adapter)
+async def test_engine_returns_not_found_when_bot_cannot_be_resolved(target, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot=None, target=target, web=adapter)
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 404, "data": {"detail": "Not found"}, "headers": None}
     assert dispatcher.webhook_update is None
 
 
 @pytest.mark.asyncio
-async def test_engine_returns_bad_request_when_json_payload_is_invalid(bot, target):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
+async def test_engine_returns_bad_request_when_json_payload_is_invalid(bot, target, adapter, dispatcher):
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
 
     response = await engine.handle_request(DummyWebRequest(DummyRequest(json_error=ValueError("invalid json"))))
 
     assert response == {"kind": "json", "status_code": 400, "data": {"detail": "Bad request"}, "headers": None}
     assert dispatcher.webhook_update is None
+
+
+@pytest.mark.asyncio
+async def test_engine_lifespan_runs_startup_then_shutdown(bot, target, adapter, dispatcher, update_request):
+    engine = EngineProbe(dispatcher, bot, target=target, web=adapter)
+
+    async with engine.lifespan(app=None):
+        assert not engine._is_shutting_down
+        response = await engine.handle_request(update_request)
+        assert response["status_code"] == 200
+
+    assert engine._is_shutting_down
+    response = await engine.handle_request(update_request)
+    assert response["status_code"] == 503

--- a/tests/test_fastapi_web.py
+++ b/tests/test_fastapi_web.py
@@ -1,7 +1,5 @@
-from contextlib import asynccontextmanager
 from typing import Any
 
-import pytest
 from aiogram.methods import SendDocument, SendMessage
 from aiogram.types import BufferedInputFile
 from fastapi import FastAPI
@@ -62,7 +60,7 @@ def test_fastapi_adapter_passes_bound_request_to_registered_post_handler():
     assert seen["json"] == {"update_id": 1}
 
 
-def test_fastapi_adapter_registers_lifecycle_callbacks_with_app_lifespan(bot):
+def test_fastapi_adapter_registers_lifecycle_callbacks_via_router(bot):
     events = []
     adapter = FastAPIAdapter()
 
@@ -84,36 +82,23 @@ def test_fastapi_adapter_registers_lifecycle_callbacks_with_app_lifespan(bot):
         def _get_task_tracker(self, bot) -> TaskTracker:
             return self._task_tracker
 
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SpyEngine(
-            DummyDispatcher(),  # ty:ignore[invalid-argument-type]
-            web=adapter,
-            route=Route(base_url="https://example.com", path="/webhook"),
-            handle_in_background=False,
-        )
+    engine = SpyEngine(
+        DummyDispatcher(),  # ty:ignore[invalid-argument-type]
+        web=adapter,
+        route=Route(base_url="https://example.com", path="/webhook"),
+        handle_in_background=False,
+    )
 
-    @asynccontextmanager
-    async def app_lifespan(app: FastAPI):
-        events.append(("app_startup", app))
-        engine.register(app)
-        async with engine.lifespan(app):
-            yield
-        events.append(("app_shutdown", app))
-
-    app = FastAPI(lifespan=app_lifespan)
+    app = FastAPI()
+    engine.register(app)
 
     with TestClient(app) as client:
-        assert events == [("app_startup", app), ("engine_startup", app)]
+        assert events == [("engine_startup", app)]
         response = client.post("/webhook", json={"update_id": 1})
 
     assert response.status_code == 200
     assert response.json() == {}
-    assert events == [
-        ("app_startup", app),
-        ("engine_startup", app),
-        ("engine_shutdown", app),
-        ("app_shutdown", app),
-    ]
+    assert events == [("engine_startup", app), ("engine_shutdown", app)]
 
 
 def test_fastapi_adapter_streams_webhook_method_payload_as_multipart(bot):

--- a/tests/test_single_bot_engine.py
+++ b/tests/test_single_bot_engine.py
@@ -6,48 +6,44 @@ from aiogram import Bot
 from aiogram_webhook.engines.single import SingleBotEngine
 from tests.fixtures.shutdown import BlockingDispatcher, BlockingShutdownDispatcher, TrackableSession
 from tests.fixtures.web_request import DummyRequest, DummyWebRequest
-from tests.fixtures.webhook_engine import CapturingAdapter, DummyDispatcher, DummyRoute
+from tests.fixtures.webhook_engine import DummyDispatcher, DummyRoute
 
 
 @pytest.mark.asyncio
-async def test_single_bot_engine_uses_configured_bot_instead_of_route_params(bot, bot_token, update_payload):
-    adapter = CapturingAdapter()
+async def test_single_bot_engine_uses_configured_bot_instead_of_route_params(bot, bot_token, adapter, update_request):
     dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": "100:OTHER"}),
-            handle_in_background=False,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": "100:OTHER"}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=False,
+    )
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
-    assert response["status_code"] == 200
+    assert response["status_code"] == 200  # ty:ignore[not-subscriptable]
     assert dispatcher.webhook_bot is bot
     assert dispatcher.webhook_bot.token == bot_token
-    assert dispatcher.webhook_update == update_payload
+    assert dispatcher.webhook_update == update_request.raw.json_data
 
 
 @pytest.mark.asyncio
-async def test_single_bot_engine_rejects_new_requests_once_shutdown_has_started(bot, update_payload):
-    adapter = CapturingAdapter()
+async def test_single_bot_engine_rejects_new_requests_once_shutdown_has_started(bot, adapter, update_request):
     dispatcher = BlockingDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": "100:OTHER"}),
-            handle_in_background=True,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": "100:OTHER"}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=True,
+    )
 
-    await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    await engine.handle_request(update_request)
     await asyncio.sleep(0)
     assert dispatcher.started_updates == 1
 
-    shutdown_task = asyncio.create_task(engine.on_shutdown(app=None))
+    shutdown_task = asyncio.create_task(engine.on_shutdown(app=None))  # ty:ignore[invalid-argument-type]
     await asyncio.sleep(0)
 
     response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data={"update_id": 2})))
@@ -55,28 +51,26 @@ async def test_single_bot_engine_rejects_new_requests_once_shutdown_has_started(
     dispatcher.release_updates.set()
     await shutdown_task
 
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.started_updates == 1
 
 
 @pytest.mark.asyncio
-async def test_background_engine_rejects_request_during_shutdown(bot, update_payload):
-    adapter = CapturingAdapter()
+async def test_background_engine_rejects_request_during_shutdown(bot, adapter, update_request):
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            handle_in_background=True,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=True,
+    )
 
-    shutdown_task = asyncio.create_task(engine.on_shutdown(None))
+    shutdown_task = asyncio.create_task(engine.on_shutdown(None))  # ty:ignore[invalid-argument-type]
     await asyncio.wait_for(dispatcher.shutdown_started.wait(), timeout=1)
 
     try:
-        response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+        response = await engine.handle_request(update_request)
         await asyncio.sleep(0)
     finally:
         dispatcher.background_continue.set()
@@ -85,88 +79,82 @@ async def test_background_engine_rejects_request_during_shutdown(bot, update_pay
         if engine._task_tracker._tasks:
             await asyncio.wait_for(asyncio.gather(*engine._task_tracker._tasks), timeout=1)
 
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.background_updates == []
     assert len(engine._task_tracker._tasks) == 0
 
 
 @pytest.mark.asyncio
-async def test_foreground_engine_rejects_request_during_shutdown(bot, update_payload):
-    adapter = CapturingAdapter()
+async def test_foreground_engine_rejects_request_during_shutdown(bot, adapter, update_request):
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            handle_in_background=False,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=False,
+    )
 
-    shutdown_task = asyncio.create_task(engine.on_shutdown(None))
+    shutdown_task = asyncio.create_task(engine.on_shutdown(None))  # ty:ignore[invalid-argument-type]
     await asyncio.wait_for(dispatcher.shutdown_started.wait(), timeout=1)
 
     try:
-        response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+        response = await engine.handle_request(update_request)
     finally:
         dispatcher.release_shutdown.set()
         await asyncio.wait_for(shutdown_task, timeout=1)
 
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.foreground_updates == []
 
 
 @pytest.mark.asyncio
-async def test_background_engine_rejects_request_after_shutdown_with_closed_bot_session(update_payload):
+async def test_background_engine_rejects_request_after_shutdown_with_closed_bot_session(adapter, update_request):
     session = TrackableSession()
     bot = Bot("42:TEST", session=session)
-    adapter = CapturingAdapter()
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            handle_in_background=True,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=True,
+    )
 
     dispatcher.release_shutdown.set()
-    await engine.on_shutdown(None)
+    await engine.on_shutdown(None)  # ty:ignore[invalid-argument-type]
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
     await asyncio.sleep(0)
     dispatcher.background_continue.set()
     if engine._task_tracker._tasks:
         await asyncio.wait_for(asyncio.gather(*engine._task_tracker._tasks), timeout=1)
 
     assert session.closed is True
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.background_updates == []
     assert dispatcher.background_session_closed == []
 
 
 @pytest.mark.asyncio
-async def test_foreground_engine_rejects_request_after_shutdown_with_closed_bot_session(update_payload):
+async def test_foreground_engine_rejects_request_after_shutdown_with_closed_bot_session(adapter, update_request):
     session = TrackableSession()
     bot = Bot("42:TEST", session=session)
-    adapter = CapturingAdapter()
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = SingleBotEngine(
-            dispatcher,
-            bot,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            handle_in_background=False,
-        )
+    engine = SingleBotEngine(
+        dispatcher,
+        bot,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        handle_in_background=False,
+    )
 
     dispatcher.release_shutdown.set()
-    await engine.on_shutdown(None)
+    await engine.on_shutdown(None)  # ty:ignore[invalid-argument-type]
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert session.closed is True
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.foreground_updates == []
     assert dispatcher.foreground_session_closed == []

--- a/tests/test_token_webhook_engine.py
+++ b/tests/test_token_webhook_engine.py
@@ -5,29 +5,28 @@ import pytest
 from aiogram_webhook.configs.bot import BotConfig
 from aiogram_webhook.engines.token import TokenEngine
 from tests.fixtures.shutdown import BlockingShutdownDispatcher
-from tests.fixtures.web_request import DummyRequest, DummyWebRequest
-from tests.fixtures.webhook_engine import CapturingAdapter, DummyDispatcher, DummyRoute
+from tests.fixtures.webhook_engine import DummyDispatcher, DummyRoute
 
 
 @pytest.mark.asyncio
-async def test_token_webhook_engine_dispatches_to_bot_resolved_from_route_token(bot, bot_id, bot_token, update_payload):
-    adapter = CapturingAdapter()
+async def test_token_webhook_engine_dispatches_to_bot_resolved_from_route_token(
+    bot, bot_id, bot_token, adapter, update_request
+):
     dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = TokenEngine(
-            dispatcher,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot_token}),
-            bot_config=BotConfig(session=bot.session),
-            handle_in_background=False,
-        )
+    engine = TokenEngine(
+        dispatcher,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot_token}),  # ty:ignore[invalid-argument-type]
+        bot_config=BotConfig(session=bot.session),
+        handle_in_background=False,
+    )
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
-    assert response["status_code"] == 200
+    assert response["status_code"] == 200  # ty:ignore[not-subscriptable]
     assert dispatcher.webhook_bot is engine.bots[bot_id]
     assert dispatcher.webhook_bot.token == bot_token
-    assert dispatcher.webhook_update == update_payload
+    assert dispatcher.webhook_update == update_request.raw.json_data
 
 
 @pytest.mark.asyncio
@@ -41,59 +40,42 @@ async def test_token_webhook_engine_dispatches_to_bot_resolved_from_route_token(
     ids=["missing", "empty", "invalid"],
 )
 async def test_token_webhook_engine_returns_not_found_when_route_token_is_missing_or_invalid(
-    bot, route_params, update_payload
+    bot, adapter, route_params, update_request
 ):
-    adapter = CapturingAdapter()
     dispatcher = DummyDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = TokenEngine(
-            dispatcher,
-            web=adapter,
-            route=DummyRoute(route_params),
-            bot_config=BotConfig(session=bot.session),
-            handle_in_background=False,
-        )
+    engine = TokenEngine(
+        dispatcher,
+        web=adapter,
+        route=DummyRoute(route_params),  # ty:ignore[invalid-argument-type]
+        bot_config=BotConfig(session=bot.session),
+        handle_in_background=False,
+    )
 
-    response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+    response = await engine.handle_request(update_request)
 
     assert response == {"kind": "json", "status_code": 404, "data": {"detail": "Not found"}, "headers": None}
     assert dispatcher.webhook_update is None
     assert engine.bots == {}
 
 
-def test_token_webhook_engine_security_warning_mentions_engine(bot, bot_token):
-    adapter = CapturingAdapter()
-    dispatcher = DummyDispatcher()
-
-    with pytest.warns(UserWarning, match="Security is not configured for TokenEngine"):
-        TokenEngine(
-            dispatcher,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot_token}),
-            bot_config=BotConfig(session=bot.session),
-        )
-
-
 @pytest.mark.asyncio
 async def test_token_background_engine_rejects_request_during_shutdown_without_creating_bot_or_tracker(
-    bot, update_payload
+    bot, adapter, update_request
 ):
-    adapter = CapturingAdapter()
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = TokenEngine(
-            dispatcher,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            bot_config=BotConfig(session=bot.session),
-            handle_in_background=True,
-        )
+    engine = TokenEngine(
+        dispatcher,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        bot_config=BotConfig(session=bot.session),
+        handle_in_background=True,
+    )
 
-    shutdown_task = asyncio.create_task(engine.on_shutdown(None))
+    shutdown_task = asyncio.create_task(engine.on_shutdown(None))  # ty:ignore[invalid-argument-type]
     await asyncio.wait_for(dispatcher.shutdown_started.wait(), timeout=1)
 
     try:
-        response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+        response = await engine.handle_request(update_request)
         await asyncio.sleep(0)
     finally:
         dispatcher.background_continue.set()
@@ -103,34 +85,34 @@ async def test_token_background_engine_rejects_request_during_shutdown_without_c
             if tracker._tasks:
                 await asyncio.wait_for(asyncio.gather(*tracker._tasks), timeout=1)
 
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.background_updates == []
     assert bot.id not in engine.bots
     assert bot.id not in engine._task_trackers
 
 
 @pytest.mark.asyncio
-async def test_token_foreground_engine_rejects_request_during_shutdown_without_creating_bot(bot, update_payload):
-    adapter = CapturingAdapter()
+async def test_token_foreground_engine_rejects_request_during_shutdown_without_creating_bot(
+    bot, adapter, update_request
+):
     dispatcher = BlockingShutdownDispatcher()
-    with pytest.warns(UserWarning, match="Security is not configured"):
-        engine = TokenEngine(
-            dispatcher,
-            web=adapter,
-            route=DummyRoute({"bot_token": bot.token}),
-            bot_config=BotConfig(session=bot.session),
-            handle_in_background=False,
-        )
+    engine = TokenEngine(
+        dispatcher,
+        web=adapter,
+        route=DummyRoute({"bot_token": bot.token}),  # ty:ignore[invalid-argument-type]
+        bot_config=BotConfig(session=bot.session),
+        handle_in_background=False,
+    )
 
-    shutdown_task = asyncio.create_task(engine.on_shutdown(None))
+    shutdown_task = asyncio.create_task(engine.on_shutdown(None))  # ty:ignore[invalid-argument-type]
     await asyncio.wait_for(dispatcher.shutdown_started.wait(), timeout=1)
 
     try:
-        response = await engine.handle_request(DummyWebRequest(DummyRequest(json_data=update_payload)))
+        response = await engine.handle_request(update_request)
     finally:
         dispatcher.release_shutdown.set()
         await asyncio.wait_for(shutdown_task, timeout=1)
 
-    assert response["status_code"] == 503
+    assert response["status_code"] == 503  # ty:ignore[not-subscriptable]
     assert dispatcher.foreground_updates == []
     assert bot.id not in engine.bots


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FastAPI adapter now automatically integrates startup/shutdown lifecycle callbacks through simplified route registration.

* **Documentation**
  * Clarified webhook engine responsibilities: endpoint registration, webhook setup, request verification, and lifecycle management.
  * Simplified FastAPI integration examples—no longer requires explicit lifespan context managers.
  * Updated security configuration guidance to emphasize engine-level configuration.

* **Chores**
  * Added warning filters to suppress expected configuration notices during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->